### PR TITLE
Update to depend upon showdown

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,9 @@
     "web": "https://github.com/showdownjs/twitter-extension"
   },
   "main": ["dist/showdown-twitter.js"],
+  "dependencies": {
+    "showdown": "^0.3.4"
+  },
   "ignore": [
     "src/",
     "test/",


### PR DESCRIPTION
The showdown extensions should depend upon showdown in the bower.json file. This helps task automation tools order the plugins in the right order. These plugins should go after showdown is already defined.