### PR TITLE
Check the correct global scope

### DIFF
--- a/src/showdown-twitter.js
+++ b/src/showdown-twitter.js
@@ -48,8 +48,8 @@
   };
 
   // Client-side export
-  if (typeof window !== 'undefined' && window.Showdown && window.Showdown.extensions) {
-    window.Showdown.extensions.twitter = twitter;
+  if (typeof window !== 'undefined' && window.showdown && window.showdown.extensions) {
+    window.showdown.extensions.twitter = twitter;
   }
   // Server-side export
   if (typeof module !== 'undefined') {


### PR DESCRIPTION
As of v1 showdown loads itself onto `window.showdown`, the twitter extension is looking for `window.Showdown` and thus doesn't register itself
